### PR TITLE
Fix: <leader>dq uses setqflist for diagnostic quickfix list

### DIFF
--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -48,7 +48,7 @@ map("v", "p", '"_dP', { desc = "Paste without yanking" })
 map("n", "[d", vim.diagnostic.goto_prev, { desc = "Previous diagnostic" })
 map("n", "]d", vim.diagnostic.goto_next, { desc = "Next diagnostic" })
 map("n", "<leader>de", vim.diagnostic.open_float, { desc = "Diagnostic float" })
-map("n", "<leader>dq", vim.diagnostic.setloclist, { desc = "Diagnostic list" })
+map("n", "<leader>dq", vim.diagnostic.setqflist, { desc = "Diagnostic quickfix list" })
 
 -- Quickfix list
 map("n", "<leader>co", "<cmd>copen<cr>",  { desc = "Open quickfix" })


### PR DESCRIPTION
## Summary
- Changed `<leader>dq` keymap from `vim.diagnostic.setloclist` to `vim.diagnostic.setqflist` to match its documented behavior as "Diagnostic quickfix list"
- This enables quickfix navigation (`]c`/`[c`) to work with diagnostics

## Problem
The keybinding was labeled "Diagnostic quickfix list" in README but used `setloclist` which populates the location list (`:lopen`). This meant `<leader>co`, `<leader>cc`, `]c`, `[c` (quickfix navigation) didn't work with it.

## Fix
Updated `lua/core/keymaps.lua:51` to use `vim.diagnostic.setqflist` instead.

Fixes #2